### PR TITLE
PST-2227: Handle `undefined array key 0`

### DIFF
--- a/src/AbstractAPI.php
+++ b/src/AbstractAPI.php
@@ -94,7 +94,7 @@ abstract class AbstractAPI
     {
         $contents = (string)$response->getBody();
 
-        if ($response->getHeader('content-type')[0] == 'application/json') {
+        if (($response->getHeader('content-type')[0] ?? null) === 'application/json') {
             $contents = json_decode($contents, true);
         }
 


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2227

Prevent warning `Undefined array key 0` when the `Content-Type` header is missing in the response