### PR TITLE
PAT-1030: Custom response types for CRDs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG PHP_VERSION=8.1
 ARG XDEBUG_VERSION="-3.1.6"
 
-FROM php:${PHP_VERSION}-cli-bookworm as dev
+FROM php:${PHP_VERSION}-cli-trixie as dev
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG XDEBUG_VERSION
@@ -14,7 +14,7 @@ COPY docker/php/php.ini /usr/local/etc/php/php.ini
 COPY docker/php/xdebug.ini /usr/local/etc/php/conf.d/
 
 RUN apt update -q \
- && apt install -y --no-install-recommends git zip unzip libzip4 libzip-dev zlib1g-dev \
+ && apt install -y --no-install-recommends git zip unzip libzip-dev zlib1g-dev \
  && docker-php-ext-install pcntl zip \
  && apt-get remove --autoremove -y libzip-dev zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG PHP_VERSION=8.1
 ARG XDEBUG_VERSION="-3.1.6"
 
-FROM php:${PHP_VERSION}-cli as dev
+FROM php:${PHP_VERSION}-cli-bookworm as dev
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG XDEBUG_VERSION

--- a/tests/AbstractAPITest.php
+++ b/tests/AbstractAPITest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace KubernetesRuntime\Tests;
+
+use GuzzleHttp\Psr7\Response;
+use KubernetesRuntime\AbstractAPI;
+use KubernetesRuntime\Client;
+use KubernetesRuntime\Tests\Fixtures\CustomCrdModel;
+use PHPUnit\Framework\TestCase;
+
+class AbstractAPITest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Configure Client for testing
+        Client::configure('https://kubernetes.example.com', [
+            'username' => 'test',
+            'password' => 'test',
+        ]);
+    }
+
+    public function testParseResponseWithCustomResponseTypes(): void
+    {
+        // Create a test API class with custom response types
+        $api = new class('test-namespace') extends AbstractAPI {
+            protected static function getCustomResponseTypes(): array
+            {
+                return [
+                    'testOperation' => [
+                        '200.' => CustomCrdModel::class,
+                    ],
+                ];
+            }
+
+            public function testParseResponse($response, $operationId)
+            {
+                return $this->parseResponse($response, $operationId);
+            }
+        };
+
+        // Create a mock response with JSON body
+        $responseBody = json_encode([
+            'kind' => 'TestCustom',
+            'apiVersion' => 'v1',
+            'metadata' => ['name' => 'test-resource'],
+        ]);
+
+        $response = new Response(200, ['content-type' => 'application/json'], $responseBody);
+
+        // Test that custom response type is used
+        $result = $api->testParseResponse($response, 'testOperation');
+
+        $this->assertInstanceOf(CustomCrdModel::class, $result);
+        $this->assertEquals('TestCustom', $result->kind);
+        $this->assertEquals('v1', $result->apiVersion);
+    }
+
+    public function testParseResponseWithoutCustomResponseTypes(): void
+    {
+        // Create a test API class without custom response types
+        $api = new class('test-namespace') extends AbstractAPI {
+            public function testParseResponse($response, $operationId)
+            {
+                return $this->parseResponse($response, $operationId);
+            }
+        };
+
+        // Create a mock response for unknown operation
+        $responseBody = json_encode([
+            'kind' => 'UnknownResource',
+            'apiVersion' => 'v1',
+            'metadata' => ['name' => 'test'],
+        ]);
+
+        $response = new Response(200, ['content-type' => 'application/json'], $responseBody);
+
+        // Test that raw array is returned when no mapping exists
+        $result = $api->testParseResponse($response, 'unknownOperation');
+
+        $this->assertIsArray($result);
+        $this->assertEquals('UnknownResource', $result['kind']);
+    }
+
+    public function testCustomResponseTypesTakePrecedenceOverStandardTypes(): void
+    {
+        // Create a test API class that overrides a standard operation
+        $api = new class('test-namespace') extends AbstractAPI {
+            protected static function getCustomResponseTypes(): array
+            {
+                return [
+                    'getCoreAPIVersions' => [
+                        '200.' => CustomCrdModel::class,
+                    ],
+                ];
+            }
+
+            public function testParseResponse($response, $operationId)
+            {
+                return $this->parseResponse($response, $operationId);
+            }
+        };
+
+        $responseBody = json_encode([
+            'kind' => 'Custom',
+            'apiVersion' => 'v1',
+        ]);
+
+        $response = new Response(200, ['content-type' => 'application/json'], $responseBody);
+
+        // Test that custom type takes precedence
+        $result = $api->testParseResponse($response, 'getCoreAPIVersions');
+
+        $this->assertInstanceOf(CustomCrdModel::class, $result);
+    }
+}

--- a/tests/Fixtures/CustomCrdModel.php
+++ b/tests/Fixtures/CustomCrdModel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace KubernetesRuntime\Tests\Fixtures;
+
+use KubernetesRuntime\AbstractModel;
+
+/**
+ * Test model for custom CRD
+ */
+class CustomCrdModel extends AbstractModel
+{
+    public string|null $kind = null;
+    public string|null $apiVersion = null;
+    public array|null $metadata = null;
+}


### PR DESCRIPTION
### Release Notes & Justification
Extend `AbstractAPI` class with `getCustomResponseTypes()` to enable response mapping from CRD endpoints.

### Plans for Customer Communication
None.

### Impact Analysis
This may affect services using k8s API.

### Change Type
Feature.

### Deployment Plan
Merge and release new version of `keboola/kubernetes-php-runtime`.

### Rollback Plan
None.

### Post-Release Support Plan
None.
