### PR TITLE
PAT-1371: Handle empty arrays for nullable object properties

### DIFF
--- a/src/AbstractModel.php
+++ b/src/AbstractModel.php
@@ -192,6 +192,15 @@ abstract class AbstractModel implements ModelInterface
                     }
                 }
             }
+        } elseif ($countValue === 0 && is_array($value) && $propertyTypes) {
+            // Handle empty arrays for nullable object properties
+            // When K8s returns an empty array for a nullable object property, convert it to null
+            foreach ($propertyTypes as $PropertyType) {
+                if (!$PropertyType->isCollection() && $PropertyType->getClassName() && $PropertyType->isNullable()) {
+                    $value = null;
+                    break;
+                }
+            }
         }
         $this->$index = $value;
 

--- a/tests/AbstractModelTest.php
+++ b/tests/AbstractModelTest.php
@@ -69,4 +69,46 @@ class AbstractModelTest extends TestCase
         $TestRawModel = new TestRawModel();
         $this->assertTrue($TestRawModel->isRawObject());
     }
+
+    public static function provideEmptyArrayHandlingTestData(): iterable
+    {
+        yield 'empty array for nullable object property (status)' => [
+            'input' => ['status' => []],
+            'propertyName' => 'status',
+            'expectedValue' => null,
+        ];
+
+        yield 'empty array for nullable object property (testModel)' => [
+            'input' => ['testModel' => []],
+            'propertyName' => 'testModel',
+            'expectedValue' => null,
+        ];
+
+        yield 'empty array for nullable object property (testObject)' => [
+            'input' => ['testObject' => []],
+            'propertyName' => 'testObject',
+            'expectedValue' => null,
+        ];
+
+        yield 'missing nullable object property remains null' => [
+            'input' => [],
+            'propertyName' => 'status',
+            'expectedValue' => null,
+        ];
+
+        yield 'empty array for collection property remains empty array' => [
+            'input' => ['metadata' => []],
+            'propertyName' => 'metadata',
+            'expectedValue' => [],
+        ];
+    }
+
+    /**
+     * @dataProvider provideEmptyArrayHandlingTestData
+     */
+    public function testEmptyArrayHandling(array $input, string $propertyName, mixed $expectedValue): void
+    {
+        $TestModel = new TestModel($input);
+        $this->assertEquals($expectedValue, $TestModel->$propertyName);
+    }
 }

--- a/tests/Fixtures/TestModel.php
+++ b/tests/Fixtures/TestModel.php
@@ -11,7 +11,7 @@ class TestModel extends AbstractModel
     public $namespace = 'test-namespace';
 
     /**
-     * @var TestRawModel
+     * @var TestRawModel|null
      */
     public $status;
 
@@ -26,12 +26,12 @@ class TestModel extends AbstractModel
     public $rawModels;
 
     /**
-     * @var AnotherTestModel
+     * @var AnotherTestModel|null
      */
     public $testModel;
 
     /**
-     * @var TestObject
+     * @var TestObject|null
      */
     public $testObject;
 


### PR DESCRIPTION
### Release Notes & Justification
Since PHP incorrectly parses an empty object as an array, we face an issue when k8s API returns `{}` for a nullable object property.

We need to handle this by converting `[]` to `null` if:
- the property is a nullable object,
- the property is not a collection
- and the decoded value is `[]`.

### Plans for Customer Communication
None.

### Impact Analysis
This may affect services using k8s API.

### Change Type
Fix.

### Deployment Plan
Merge and release new version of `keboola/kubernetes-php-runtime`.

### Rollback Plan
None.

### Post-Release Support Plan
None.
